### PR TITLE
修复CTC连字问题

### DIFF
--- a/app/src/main/jni/ppocrv5.cpp
+++ b/app/src/main/jni/ppocrv5.cpp
@@ -389,7 +389,7 @@ int PPOCRv5::recognize(const cv::Mat& rgb, Object& object)
             }
         }
 
-        if (last_token == index) //CTC规则，相邻index相同视为同一个字
+        if (last_token == index) // CTC rule, if index is same as last one, they will be merged into one token
                 continue;
 
         last_token = index;

--- a/app/src/main/jni/ppocrv5.cpp
+++ b/app/src/main/jni/ppocrv5.cpp
@@ -371,6 +371,8 @@ int PPOCRv5::recognize(const cv::Mat& rgb, Object& object)
     ex.extract("out0", out);
 
     // 18385 x len
+    int last_token = 0;
+
     for (int i = 0; i < out.h; i++)
     {
         const float* p = out.row(i);
@@ -386,6 +388,11 @@ int PPOCRv5::recognize(const cv::Mat& rgb, Object& object)
                 index = j;
             }
         }
+
+        if (last_token == index) //CTC规则，相邻index相同视为同一个字
+                continue;
+
+        last_token = index;
 
         if (index <= 0)
             continue;


### PR DESCRIPTION
CTC规定相邻index相同视为一个字符，若不识别则容易出现重字